### PR TITLE
feat: add `@Patch` decorator

### DIFF
--- a/.changeset/itchy-moose-stick.md
+++ b/.changeset/itchy-moose-stick.md
@@ -1,0 +1,5 @@
+---
+"@auralis/core": minor
+---
+
+feat: add `@Patch` decorator

--- a/examples/cat-rest-api/src/cats/cat.controller.ts
+++ b/examples/cat-rest-api/src/cats/cat.controller.ts
@@ -2,6 +2,7 @@ import {
   Delete,
   Get,
   NotFoundResponseError,
+  Patch,
   PathVariable,
   Post,
   Put,
@@ -24,7 +25,7 @@ export class CatController {
   }
 
   @Get("/:id")
-  public getById(@PathVariable() id: UUID): Cat | null {
+  public getById(@PathVariable() id: UUID): Cat {
     const foundCat = cats.find((cat) => cat.id === id);
 
     if (!foundCat) {
@@ -43,13 +44,29 @@ export class CatController {
 
   @Put("/:id")
   public update(@PathVariable() id: UUID, @RequestBody(Cat) cat: Cat): Cat {
-    const index = cats.findIndex((c) => c.id === id);
-    if (index === -1) {
+    const foundCat = cats.find((c) => c.id === id);
+    if (!foundCat) {
       throw new NotFoundResponseError("Cat not found");
     }
 
-    cats[index] = cat;
-    return cat;
+    Object.assign(foundCat, cat);
+    foundCat.id = id; // Ensure the ID remains the same
+    return foundCat;
+  }
+
+  @Patch("/:id")
+  public partialUpdate(
+    @PathVariable() id: UUID,
+    @RequestBody(Cat) cat: Partial<Cat>
+  ): Cat {
+    const foundCat = cats.find((c) => c.id === id);
+    if (!foundCat) {
+      throw new NotFoundResponseError("Cat not found");
+    }
+
+    Object.assign(foundCat, cat);
+    foundCat.id = id; // Ensure the ID remains the same
+    return foundCat;
   }
 
   @Delete("/:id")

--- a/packages/core/src/decorators/patch.decorator.ts
+++ b/packages/core/src/decorators/patch.decorator.ts
@@ -1,0 +1,8 @@
+import { HttpMethod } from "./http-method.decorator.ts";
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/PATCH
+ */
+export function Patch(path: string): MethodDecorator {
+  return HttpMethod("PATCH", path);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export type { Auralis } from "./auralis.ts";
 export { Delete } from "./decorators/delete.decorator.ts";
 export { Get } from "./decorators/get.decorator.ts";
 export { HttpMethod } from "./decorators/http-method.decorator.ts";
+export { Patch } from "./decorators/patch.decorator.ts";
 export { PathVariable } from "./decorators/path-variable.decorator.ts";
 export { Post } from "./decorators/post.decorator.ts";
 export { Put } from "./decorators/put.decorator.ts";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PATCH method decorator to the core package so apps can declare PATCH endpoints.
  * Example REST API gains partial-update support for cats (PATCH /cats/:id) that merges provided fields and preserves IDs.
* **Refactor**
  * Retrieval now returns 404 for missing entities instead of null, improving consistency.
* **Chores**
  * Added release metadata for a minor version update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->