### PR TITLE
feat: add `@Controller` decorator

### DIFF
--- a/.changeset/chilly-carrots-kneel.md
+++ b/.changeset/chilly-carrots-kneel.md
@@ -1,0 +1,5 @@
+---
+"@auralis/core": minor
+---
+
+feat: add `@Controller` decorator

--- a/packages/core/src/decorators/controller.decorator.ts
+++ b/packages/core/src/decorators/controller.decorator.ts
@@ -2,28 +2,25 @@ import type { Constructor } from "../utilities/constructor.util.ts";
 import { ensureControllerRef } from "../utilities/registry.util.ts";
 
 /**
- * REST controller decorator for defining a RESTful controller class.
+ * Controller decorator for defining a controller class.
  *
- * This decorator applies the `Content-Type: application/json; charset=utf-8` response header.
+ * This decorator does not apply response headers.
  *
  * @param path The base path for the controller that usually starts with a slash.
  *
- * @see `Controller` if you want to create a basic controller that does not apply response headers.
+ * @see `RestController` if you want to create a RESTful controller.
  */
-export function RestController(path: string): ClassDecorator {
+export function Controller(path: string): ClassDecorator {
   return function (target) {
     const controller = target as unknown as Constructor;
 
     const controllerRef = ensureControllerRef(controller);
 
-    // TODO @Shinigami92 2025-08-11: Is `args[0].name` needed?
     controllerRef.path = path;
     controllerRef.responseHeaders ??= {};
-    controllerRef.responseHeaders["Content-Type"] =
-      "application/json; charset=utf-8";
 
     if (process.env.AURALIS_DEBUG) {
-      console.debug("[RestController]:", {
+      console.debug("[Controller]:", {
         args: [target],
         controller,
         path,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export type { Auralis } from "./auralis.ts";
+export { Controller } from "./decorators/controller.decorator.ts";
 export { Delete } from "./decorators/delete.decorator.ts";
 export { Get } from "./decorators/get.decorator.ts";
 export { HttpMethod } from "./decorators/http-method.decorator.ts";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Controller decorator to define a base route for controllers, now available in the core package exports.

- Documentation
  - Improved RestController documentation, clarifying that it applies a JSON Content-Type header by default.

- Chores
  - Added a changeset entry to publish a minor release of the core package reflecting the new public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->